### PR TITLE
[#133] Add reset button to Multi-Turn Memory Timeline demo

### DIFF
--- a/src/patterns/multi-turn-memory/MultiTurnMemoryDemo.module.css
+++ b/src/patterns/multi-turn-memory/MultiTurnMemoryDemo.module.css
@@ -82,6 +82,23 @@
   border-color: var(--border-hover, #555);
 }
 
+.resetButton {
+  padding: 0.5rem 1rem;
+  background: var(--surface-2, #1a1a1a);
+  border: 1px solid var(--border-color, #444);
+  border-radius: 6px;
+  color: var(--text-primary, #fff);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.resetButton:hover {
+  background: var(--primary, #3b82f6);
+  border-color: var(--primary, #3b82f6);
+  color: #fff;
+}
+
 .memorySection {
   background: var(--surface-1, #0a0a0a);
   border-bottom: 1px solid var(--border-color, #333);

--- a/src/patterns/multi-turn-memory/MultiTurnMemoryDemo.test.tsx
+++ b/src/patterns/multi-turn-memory/MultiTurnMemoryDemo.test.tsx
@@ -74,4 +74,9 @@ describe('MultiTurnMemoryDemo', () => {
     render(<MultiTurnMemoryDemo />);
     expect(screen.getByText('Stream Speed:')).toBeInTheDocument();
   });
+
+  it('renders reset demo button', () => {
+    render(<MultiTurnMemoryDemo />);
+    expect(screen.getByRole('button', { name: /reset demo/i })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a Reset Demo button to the Multi-Turn Memory Timeline pattern demo
- Splits component into wrapper + content architecture to enable proper reset via React key change
- Speed changes now also reset the demo for consistent behavior

## Implementation
- `MultiTurnMemoryDemo` (wrapper): Manages demo-level state (speed, filters visibility, demoKey)
- `MemoryDemoContent` (inner): Contains the hook and all memory-related state, keyed for reset
- When Reset button is clicked, `demoKey` increments, causing React to remount `MemoryDemoContent`

## Test plan
- [x] Type check passes
- [x] All existing tests pass (19 tests)
- [x] New test for reset button rendering
- [ ] Manual verification: Reset button appears and resets demo when clicked

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)