### PR TITLE
[#134] Fix night mode text visibility in Turn-Taking demo

### DIFF
--- a/src/patterns/turn-taking-co-creation/CollaborativeEditor.module.css
+++ b/src/patterns/turn-taking-co-creation/CollaborativeEditor.module.css
@@ -322,7 +322,8 @@
   font-family: inherit;
   font-size: 0.9375rem;
   line-height: 1.6;
-  color: var(--color-text-primary, #111827);
+  /* Hardcoded dark text color to ensure visibility on white background in all themes */
+  color: #111827;
   background-color: white;
   border: 2px solid var(--color-user-text, #065f46);
   border-radius: 6px;
@@ -332,6 +333,11 @@
 
 .editTextarea:focus {
   box-shadow: 0 0 0 3px var(--color-user-bg, #d1fae5);
+}
+
+/* Ensure placeholder text is visible in all themes */
+.editTextarea::placeholder {
+  color: #9ca3af;
 }
 
 .clickableContent {


### PR DESCRIPTION
## Summary
- Fixes invisible text in the Turn-Taking Co-Creation demo's textarea input field when using dark/night mode

## Root Cause
The textarea had:
- `background-color: white;` (hardcoded)
- `color: var(--color-text-primary, #111827);` (CSS variable)

In dark mode, `--color-text-primary` becomes `#F9FAFB` (light/white), resulting in white text on white background.

## Fix
- Hardcode text color to `#111827` (dark) to match the white background
- Add explicit placeholder color `#9ca3af` for consistency

## Test plan
- [x] All existing tests pass (42 tests)
- [ ] Manual verification: Text is visible in both light and dark modes

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)