### PR TITLE
[#142] Fix review-pr.md command to remove merge/Done instructions

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,11 +1,11 @@
 ---
-description: Review pull requests in the In Review column and merge if approved
+description: Review pull requests in the In Review column and provide GO/NO-GO recommendation (human merges)
 ---
 
-Launch the pr-reviewer-merger agent to:
+Launch the pr-reviewer agent to:
 - Find pull requests linked to tickets in the In Review column on https://github.com/orgs/vibeacademy/projects/3
 - Conduct thorough code review against project standards
 - Verify tests pass, TypeScript compliance, and pattern implementation correctness
-- Approve and merge PRs that meet quality standards
+- Post a detailed GO/NO-GO review comment for each PR
 - Request changes for PRs that need improvement
-- Move merged tickets to Done column
+- Tag PRs as "Ready for human merge" but DO NOT merge or move tickets to Done


### PR DESCRIPTION
## Ticket
Closes #142
https://github.com/vibeacademy/streaming-patterns/issues/142

## Summary
This is a P0 - Critical safety fix that resolves conflicting instructions in the `/review-pr` slash command. The command previously told the agent to "merge if approved" and "move merged tickets to Done column", which directly contradicted the pr-reviewer-merger agent policy and caused agent confusion leading to unsafe behavior.

## Changes Made
- **Updated description**: Changed from "Review pull requests in the In Review column and merge if approved" to "Review pull requests in the In Review column and provide GO/NO-GO recommendation (human merges)"
- **Replaced merge instruction**: Changed "Approve and merge PRs that meet quality standards" to "Post a detailed GO/NO-GO review comment for each PR"
- **Removed Done column instruction**: Deleted "Move merged tickets to Done column"
- **Added explicit prohibition**: Added "Tag PRs as 'Ready for human merge' but DO NOT merge or move tickets to Done"
- **Updated agent reference**: Changed from "pr-reviewer-merger agent" to "pr-reviewer agent"

## File Modified
- `.claude/commands/review-pr.md` - Updated slash command to align with safety protocols

## Safety Impact
This fix ensures the `/review-pr` command aligns with the three-stage workflow:
1. **github-ticket-worker** implements and creates PR
2. **pr-reviewer** reviews and provides GO/NO-GO recommendation
3. **Human** performs final merge

By removing the conflicting "merge" and "move to Done" instructions, we eliminate the agent confusion that previously led to unsafe behavior where the agent attempted to merge PRs and close tickets.

## Testing
### Manual Testing
1. Read the updated `.claude/commands/review-pr.md` file
2. Verify description no longer contains "merge if approved"
3. Verify body does not instruct agent to merge or move tickets to Done
4. Verify explicit prohibition is present: "DO NOT merge or move tickets to Done"
5. Confirm alignment with pr-reviewer agent policy

### Acceptance Criteria
- [x] review-pr.md description changed to remove "merge" language
- [x] Body text explicitly states agent does NOT merge
- [x] No mention of "move to Done column"
- [x] Aligns with pr-reviewer-merger.md agent policy

## Context
This is part of the Agent Workflow Hardening initiative documented in `plans/agent-workflow-hardening.md`. This fix addresses the immediate instruction conflict that was causing agents to attempt unauthorized merges and ticket closures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>