### PR TITLE
Document GitHub account switching in agent policies

### DIFF
--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -41,6 +41,23 @@ The fictional business context is "StreamFlow PM" - a modern project management 
 
 ## Tools and Capabilities
 
+**CRITICAL: GitHub Account Identity**
+
+This agent MUST operate as the `va-worker` GitHub account. Before ANY GitHub operations:
+
+```bash
+# Switch to va-worker account
+gh auth switch --user va-worker
+
+# Verify correct account is active
+gh auth status | grep "Active account: true" | grep "va-worker"
+```
+
+**Why this matters:**
+- Git commits and PRs are properly attributed to `va-worker`
+- Separation of duties: `va-worker` creates, `va-reviewer` reviews, human merges
+- Human can distinguish between worker and reviewer actions in the audit trail
+
 **GitHub MCP Server**: You have access to the GitHub MCP server with native tools for interacting with issues, pull requests, and the project board. This is your **primary method** for all GitHub operations.
 
 **Available MCP Tools (Preferred):**

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -56,6 +56,23 @@ This is an educational pattern library teaching frontend developers how to build
 
 ## Tools and Capabilities
 
+**CRITICAL: GitHub Account Identity**
+
+This agent MUST operate as the `va-reviewer` GitHub account. Before ANY GitHub operations:
+
+```bash
+# Switch to va-reviewer account
+gh auth switch --user va-reviewer
+
+# Verify correct account is active
+gh auth status | grep "Active account: true" | grep "va-reviewer"
+```
+
+**Why this matters:**
+- PR reviews from `va-reviewer` are properly attributed
+- Separation of duties: `va-worker` creates PRs, `va-reviewer` reviews them
+- Human can distinguish between worker and reviewer actions in the audit trail
+
 **GitHub MCP Server**: You have access to the GitHub MCP server with native tools for interacting with pull requests, issues, and the project board. This is your **primary method** for all GitHub operations.
 
 **Available MCP Tools (Preferred):**


### PR DESCRIPTION
## Summary

Adds explicit documentation to both agent policies (`pr-reviewer` and `github-ticket-worker`) requiring them to operate with the correct GitHub account identity.

## Problem

Previously, agents would inherit whatever GitHub account was currently active in the gh CLI, leading to:
- PR reviews posted by `va-worker` instead of `va-reviewer`
- Confusing audit trail where different accounts perform actions outside their roles
- User having to manually remind about account switching

User feedback: "how will you remember to switch accounts in the future? i shouldn't have to remind you"

## Solution

Added "CRITICAL: GitHub Account Identity" sections to both agent policies documenting:

**pr-reviewer** MUST use `va-reviewer` account:
```bash
gh auth switch --user va-reviewer
```

**github-ticket-worker** MUST use `va-worker` account:
```bash
gh auth switch --user va-worker
```

## Changes Made

1. **`.claude/agents/pr-reviewer.md`** - Added account switching requirement
2. **`.claude/agents/github-ticket-worker.md`** - Added account switching requirement

## Impact

- ✅ Agents now explicitly document which account they must use
- ✅ Proper separation of duties enforced at the policy level
- ✅ Audit trail correctly attributes actions (worker creates, reviewer reviews)
- ✅ User no longer needs to manually remind about account switching
- ✅ Workflow documentation is self-contained in agent policies

## Testing

Verified with PR #164 and #165 reviews:
1. Initially ran pr-reviewer with va-worker account (incorrect)
2. Updated policies, switched to va-reviewer, re-ran agent
3. Reviews successfully posted with correct account attribution

## Checklist

- [x] Documentation updated
- [x] Policy changes are clear and enforceable
- [x] Tested with live PR reviews
- [x] Resolves user feedback about account switching

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>