### PR TITLE
[#178] Fix memory tooltip overflow clipping

### DIFF
--- a/src/patterns/multi-turn-memory/MemoryTimeline.module.css
+++ b/src/patterns/multi-turn-memory/MemoryTimeline.module.css
@@ -15,7 +15,9 @@
   display: flex;
   gap: 1rem;
   overflow-x: auto;
+  overflow-y: visible;
   padding-bottom: 0.5rem;
+  padding-top: 3rem; /* Space for tooltip to show above cards */
   scroll-behavior: smooth;
 }
 

--- a/src/patterns/multi-turn-memory/MultiTurnMemoryDemo.tsx
+++ b/src/patterns/multi-turn-memory/MultiTurnMemoryDemo.tsx
@@ -308,7 +308,7 @@ export function MultiTurnMemoryDemo(): JSX.Element {
         <div className={styles.infoSection}>
           <h3 className={styles.infoTitle}>Try It Out</h3>
           <ul className={styles.actionList}>
-            <li>Hover over a memory card to see the token excerpt</li>
+            <li>Hover over a memory card to see a tooltip with the token excerpt</li>
             <li>Click the pin icon to prevent auto-pruning</li>
             <li>Click the X to manually prune a memory</li>
             <li>Use filters to focus on specific memory types</li>


### PR DESCRIPTION
## Ticket
Closes #178
https://github.com/vibeacademy/streaming-patterns/issues/178

## Summary
Fixed the hover tooltip for memory cards in the Multi-Turn Memory pattern. The tooltip was fully implemented but wasn't visible due to CSS overflow clipping in the scroll container.

## Changes Made
- **MemoryTimeline.module.css**: Added `overflow-y: visible` to `.scrollContainer` to prevent tooltip clipping
- **MemoryTimeline.module.css**: Added `padding-top: 3rem` to provide space for tooltip to appear above cards
- **MultiTurnMemoryDemo.tsx**: Updated "Try It Out" instruction to explicitly mention "tooltip" for clarity

## Root Cause
The tooltip component was already fully implemented with:
- Hover detection (`onMouseEnter`/`onMouseLeave`)
- Tooltip rendering with token excerpt
- Complete CSS styling with animations

However, the `.scrollContainer` had `overflow-x: auto` which was clipping the absolutely positioned tooltip that appears above the card.

## Solution
Added `overflow-y: visible` to allow vertical overflow while maintaining horizontal scrolling. Added padding-top to ensure sufficient space for the tooltip.

## Testing
### Automated Tests
- [x] All 881 tests pass
- [x] No new linting errors
- [x] Build successful

### Manual Testing
1. Run `npm run dev`
2. Navigate to `/patterns/multi-turn-memory`
3. Hover over a memory card
4. ✅ Tooltip appears above the card showing token excerpt
5. ✅ Tooltip is properly positioned and styled
6. ✅ Horizontal scrolling still works correctly

## Files Modified
- `/Users/teddykim/projects/vibeacademy/streaming-patterns/src/patterns/multi-turn-memory/MemoryTimeline.module.css`
- `/Users/teddykim/projects/vibeacademy/streaming-patterns/src/patterns/multi-turn-memory/MultiTurnMemoryDemo.tsx`

## Checklist
- [x] All tests pass (`npm test`)
- [x] Code follows TypeScript strict mode
- [x] No eslint warnings introduced
- [x] Built successfully (`npm run build`)
- [x] Tooltip functionality now works as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>