### PR TITLE
[#184] Fix Cloudflare routes API error 10013 for staging deploys

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -32,5 +32,8 @@ ENVIRONMENT = "production"
 [env.staging]
 name = "streaming-patterns-staging"
 workers_dev = true
+# Explicitly disable routes for staging (uses workers.dev subdomain)
+# This prevents Cloudflare API error 10013 when routes are inherited from parent config
+routes = []
 vars = { ENVIRONMENT = "staging" }
 


### PR DESCRIPTION
## Ticket
Closes #184

## Summary
Fixes the Cloudflare API error 10013 that was causing false deployment failures in the staging environment. The issue was caused by the staging environment inheriting the `routes` configuration from the parent wrangler.toml, which is incompatible with `workers_dev = true`.

## Changes Made
- **wrangler.toml**: Added `routes = []` to the `[env.staging]` section to explicitly disable routes for staging
- Added inline comments explaining why routes are disabled for staging

## Root Cause Analysis
The staging environment configuration was inheriting the parent `routes` array, which defines custom domain routes for production (`streamingpatterns.com/*`). When deploying to staging with `workers_dev = true`, Cloudflare attempts to configure these routes but fails with error 10013 because:

1. Staging uses the workers.dev subdomain (no custom domain)
2. The routes API call is incompatible with workers_dev deployments
3. The inherited routes configuration was never intended for staging

## Solution
By explicitly setting `routes = []` in the staging environment configuration, we override the parent configuration and prevent the routes API call entirely. This is the correct configuration for staging since it uses workers.dev and doesn't need custom routes.

## Testing
### Build Verification
- No build step needed (configuration-only change)
- File syntax is valid TOML

### Deployment Validation
The fix will be validated by:
1. The next deployment to staging via GitHub Actions
2. Verifying no error 10013 in the deployment logs
3. Confirming the workflow shows green checkmark
4. Ensuring staging worker is still accessible at workers.dev subdomain

## Impact
- Eliminates false deployment failures in GitHub Actions
- Improves developer experience (no more confusing red X on successful deploys)
- Prevents potential merge blockers if branch protection requires passing checks
- Staging deployments will now succeed cleanly without API errors

## Checklist
- [x] Configuration change follows Cloudflare Workers best practices
- [x] Comments explain the reasoning for the configuration
- [x] No code changes required (infrastructure-only)
- [x] No tests required (configuration-only change)
- [x] Workflow file already has continue-on-error as safety net
- [x] Fix addresses root cause (not just symptom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>