### PR TITLE
[#193] Fix excessive padding in tabular-stream-view scenario card

### DIFF
--- a/src/patterns/tabular-stream-view/TabularStreamViewDemo.module.css
+++ b/src/patterns/tabular-stream-view/TabularStreamViewDemo.module.css
@@ -121,23 +121,7 @@
 
 /* Scenario */
 .scenario {
-  padding: 20px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  border-radius: 8px;
-}
-
-.scenarioTitle {
-  font-size: 20px;
-  font-weight: 600;
-  margin: 0 0 8px 0;
-}
-
-.scenarioDescription {
-  font-size: 15px;
-  line-height: 1.6;
-  margin: 0;
-  opacity: 0.95;
+  /* ScenarioCard component handles its own styling */
 }
 
 /* Error */


### PR DESCRIPTION
## Ticket
Closes #193

## Summary
Removed excessive padding and gradient background from the scenario wrapper div in the Tabular Stream View pattern. The wrapper was applying 20px padding and a purple gradient background that conflicted with the ScenarioCard component's own styling, making it inconsistent with other pattern demos.

## Changes Made
- Removed padding, background gradient, and border-radius from `.scenario` wrapper class in `TabularStreamViewDemo.module.css`
- Removed unused `.scenarioTitle` and `.scenarioDescription` styles (these were never used since ScenarioCard handles its own styling)
- Added comment clarifying that ScenarioCard handles its own styling

## Pattern Consistency
This fix aligns the Tabular Stream View pattern with the standard approach used in other patterns:
- Chain of Reasoning: `.scenarioSection` with only margin-bottom
- Turn-Taking Co-Creation: `.scenarioSection` with only margin-bottom
- Multi-Turn Memory: `.scenario` wrapper with minimal styling
- Streaming Validation Loop: `.scenario` wrapper with no special styling
- Agent-Await-Prompt: `.scenario` wrapper with no special styling
- Schema-Governed Exchange: `.scenario` wrapper with no special styling

## Testing
### Automated Tests
- [x] Lint passes with no new warnings
- [x] Build succeeds with no errors
- [x] No test changes required (pure CSS fix)

### Manual Testing
The ScenarioCard component now displays with consistent padding matching other pattern demos. The card's built-in styling (via Card component) provides proper spacing without the conflicting wrapper styles.

## Before/After
**Before:** ScenarioCard wrapped in div with 20px padding + purple gradient background
**After:** ScenarioCard with standard Card component styling, consistent with other patterns

## Checklist
- [x] All tests pass (npm test)
- [x] Code follows TypeScript strict mode
- [x] No eslint warnings introduced
- [x] Built successfully (npm run build)
- [x] CSS follows pattern consistency standards
- [x] Matches styling approach used in other pattern demos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>