### PR TITLE
[#211] Fix Home page hardcoded colors (9 violations)

### DIFF
--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -21,7 +21,7 @@
   font-size: 3rem;
   font-weight: 800;
   margin: 0 0 1rem;
-  background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+  background: var(--brand-gradient-primary);
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -84,7 +84,7 @@
 }
 
 .patternLink:focus {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
   border-radius: 8px;
 }
@@ -121,8 +121,8 @@
   font-size: 0.75rem;
   padding: 0.25rem 0.75rem;
   border-radius: 9999px;
-  background-color: #d1fae5;
-  color: #065f46;
+  background-color: var(--color-success-50);
+  color: var(--color-success-700);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -133,8 +133,8 @@
   flex-direction: column;
   transition: box-shadow 0.2s ease;
   opacity: 0.85;
-  background: linear-gradient(to bottom right, #ffffff, #f9fafb);
-  border: 1px dashed #d1d5db;
+  background: linear-gradient(to bottom right, var(--color-bg-primary), var(--color-bg-secondary));
+  border: var(--border-width-thin) dashed var(--color-border-medium);
 }
 
 .comingSoonCard:hover {
@@ -147,8 +147,8 @@
   font-size: 0.75rem;
   padding: 0.25rem 0.75rem;
   border-radius: 9999px;
-  background-color: #fef3c7;
-  color: #92400e;
+  background-color: var(--color-warning-50);
+  color: var(--color-warning-700);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -197,13 +197,13 @@
   content: '→';
   position: absolute;
   left: 0;
-  color: #3b82f6;
+  color: var(--color-primary);
   font-weight: 600;
 }
 
 .patternCta {
   font-weight: 600;
-  color: #3b82f6;
+  color: var(--color-primary);
   margin-top: auto;
 }
 


### PR DESCRIPTION
## Ticket
Closes #211
https://github.com/vibeacademy/streaming-patterns/issues/211

## Summary
Fixed all 9 hardcoded color violations in Home.module.css by replacing hex colors with semantic CSS variables from the theme system. The Home page now fully supports both light and dark modes.

## Changes Made
- **src/pages/Home.module.css**: Replaced all 9 hardcoded hex colors with theme-aware CSS variables

### Color Mappings
- Title gradient: `linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)` → `var(--brand-gradient-primary)`
- Pattern link focus: `#3b82f6` → `var(--color-primary)`
- Pattern status badge: `#d1fae5`/`#065f46` → `var(--color-success-50)`/`var(--color-success-700)`
- Coming soon card background: `linear-gradient(#ffffff, #f9fafb)` → `linear-gradient(var(--color-bg-primary), var(--color-bg-secondary))`
- Coming soon card border: `#d1d5db` → `var(--color-border-medium)`
- Coming soon status badge: `#fef3c7`/`#92400e` → `var(--color-warning-50)`/`var(--color-warning-700)`
- Techniques list arrow: `#3b82f6` → `var(--color-primary)`
- Pattern CTA: `#3b82f6` → `var(--color-primary)`

## Testing

### Automated Tests
- [x] Unit tests pass
- [x] Component tests pass
- [x] Integration tests pass
- [x] Coverage meets threshold

### Manual Testing
1. Run `npm run dev`
2. Navigate to `/` (home page)
3. Verify page displays correctly in light mode
4. Toggle to dark mode
5. Verify title gradient is visible in dark mode
6. Check pattern cards and badges are readable
7. Verify coming soon cards have proper contrast
8. Test hover states on pattern links
9. Verify focus indicators work correctly

## Checklist
- [x] All tests pass (`npm test`)
- [x] Code follows TypeScript strict mode
- [x] All hardcoded colors replaced with CSS variables
- [x] No eslint warnings
- [x] Built successfully (`npm run build`)
- [x] Home page readable in both light and dark modes
- [x] Title gradient visible in both themes
- [x] Status badges use semantic color variables
- [x] Links and CTAs use theme-aware primary color

🤖 Generated with [Claude Code](https://claude.com/claude-code)