### PR TITLE
[#212] Fix Patterns page hardcoded colors (7 violations)

### DIFF
--- a/src/pages/Patterns.module.css
+++ b/src/pages/Patterns.module.css
@@ -33,7 +33,7 @@
 
 .progressIndicator {
   font-size: 1rem;
-  color: #3b82f6;
+  color: var(--color-primary);
   margin: 0;
 }
 
@@ -80,7 +80,7 @@
 }
 
 .patternLink:focus {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
   border-radius: 8px;
 }
@@ -122,8 +122,8 @@
   font-size: 0.75rem;
   padding: 0.25rem 0.75rem;
   border-radius: 9999px;
-  background-color: #d1fae5;
-  color: #065f46;
+  background-color: var(--color-success-50);
+  color: var(--color-success-700);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -132,8 +132,8 @@
   font-size: 0.75rem;
   padding: 0.25rem 0.75rem;
   border-radius: 9999px;
-  background-color: #f3f4f6;
-  color: #6b7280;
+  background-color: var(--color-neutral-100);
+  color: var(--color-neutral-500);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -164,8 +164,8 @@
   display: inline-block;
   padding: 0.125rem 0.5rem;
   border-radius: 4px;
-  background-color: #eff6ff;
-  color: #1e40af;
+  background-color: var(--color-info-50);
+  color: var(--color-info-700);
   font-size: 0.8125rem;
   font-weight: 500;
 }
@@ -177,7 +177,7 @@
 
 .patternCta {
   font-weight: 600;
-  color: #3b82f6;
+  color: var(--color-primary);
   margin-top: auto;
 }
 


### PR DESCRIPTION
## Ticket
Closes #212
https://github.com/vibeacademy/streaming-patterns/issues/212

## Summary
Fixed all 7 hardcoded color violations in Patterns.module.css by replacing hex colors with semantic CSS variables from the theme system. The Patterns page now fully supports both light and dark modes.

## Changes Made
- **src/pages/Patterns.module.css**: Replaced all 7 hardcoded hex colors with theme-aware CSS variables

### Color Mappings
- Progress indicator: `#3b82f6` → `var(--color-primary)`
- Pattern link focus: `#3b82f6` → `var(--color-primary)`
- Status badge: `#d1fae5`/`#065f46` → `var(--color-success-50)`/`var(--color-success-700)`
- Coming soon badge: `#f3f4f6`/`#6b7280` → `var(--color-neutral-100)`/`var(--color-neutral-500)`
- Difficulty badge: `#eff6ff`/`#1e40af` → `var(--color-info-50)`/`var(--color-info-700)`
- Pattern CTA: `#3b82f6` → `var(--color-primary)`

## Testing

### Automated Tests
- [x] Unit tests pass
- [x] Component tests pass
- [x] Integration tests pass
- [x] Coverage meets threshold

### Manual Testing
1. Run `npm run dev`
2. Navigate to `/patterns`
3. Verify page displays correctly in light mode
4. Toggle to dark mode
5. Verify all badges are readable with proper contrast
6. Check pattern cards display correctly
7. Test hover states on pattern links
8. Verify focus indicators work correctly

## Checklist
- [x] All tests pass (`npm test`)
- [x] Code follows TypeScript strict mode
- [x] All hardcoded colors replaced with CSS variables
- [x] No eslint warnings
- [x] Built successfully (`npm run build`)
- [x] Patterns page readable in both light and dark modes
- [x] All badge contrast ratios meet WCAG (4.5:1)
- [x] Links and CTAs use theme-aware primary color

🤖 Generated with [Claude Code](https://claude.com/claude-code)