### PR TITLE
[#217] Add ARIA live regions to all pattern demos

### DIFF
--- a/src/patterns/agent-await-prompt/AgentAwaitPromptDemo.tsx
+++ b/src/patterns/agent-await-prompt/AgentAwaitPromptDemo.tsx
@@ -268,7 +268,12 @@ export default function AgentAwaitPromptDemo(): JSX.Element {
           )}
 
           {/* Text content */}
-          <div className={styles.messageText}>
+          <div
+            role="log"
+            aria-live="polite"
+            aria-label="Streaming message"
+            className={styles.messageText}
+          >
             {text || <span className={styles.placeholder}>Waiting for stream...</span>}
           </div>
 

--- a/src/patterns/chain-of-reasoning/ChainOfReasoningDemo.tsx
+++ b/src/patterns/chain-of-reasoning/ChainOfReasoningDemo.tsx
@@ -405,10 +405,16 @@ export function ChainOfReasoningDemo(): JSX.Element {
             </span>
           </div>
 
-          <ReasoningBeadline
-            reasoning={reasoning}
-            className={styles.beadline}
-          />
+          <div
+            role="log"
+            aria-live="polite"
+            aria-label="Streaming reasoning steps"
+          >
+            <ReasoningBeadline
+              reasoning={reasoning}
+              className={styles.beadline}
+            />
+          </div>
 
           {!isStreaming && reasoning.length === 0 && (
             <div className={styles.emptyState}>
@@ -431,7 +437,12 @@ export function ChainOfReasoningDemo(): JSX.Element {
             </div>
 
             <Card className={styles.answerCard}>
-              <div className={styles.answerContent}>
+              <div
+                role="log"
+                aria-live="polite"
+                aria-label="Final answer"
+                className={styles.answerContent}
+              >
                 {/*
                   Note: For MVP, we'll render the answer as plain text.
                   In a future iteration, we can add markdown rendering.

--- a/src/patterns/multi-turn-memory/MultiTurnMemoryDemo.tsx
+++ b/src/patterns/multi-turn-memory/MultiTurnMemoryDemo.tsx
@@ -137,7 +137,13 @@ function MemoryDemoContent({ speed, showFilters, showInspector, capturedEvents, 
             )}
           </div>
 
-          <ChatThread messages={messages} isStreaming={isStreaming} />
+          <div
+            role="log"
+            aria-live="polite"
+            aria-label="Chat conversation history"
+          >
+            <ChatThread messages={messages} isStreaming={isStreaming} />
+          </div>
         </main>
       </div>
 

--- a/src/patterns/schema-governed-exchange/SchemaExchangeDemo.tsx
+++ b/src/patterns/schema-governed-exchange/SchemaExchangeDemo.tsx
@@ -254,11 +254,17 @@ export function SchemaExchangeDemo() {
 
         {/* Right Panel - Payload & Errors */}
         <div className={styles.rightPanel}>
-          <PayloadViewer
-            payload={payload}
-            errors={allErrors}
-            isComplete={isComplete}
-          />
+          <div
+            role="log"
+            aria-live="polite"
+            aria-label="Streaming JSON payload"
+          >
+            <PayloadViewer
+              payload={payload}
+              errors={allErrors}
+              isComplete={isComplete}
+            />
+          </div>
 
           {allErrors.length > 0 && (
             <div className={styles.errorSection}>

--- a/src/patterns/streaming-validation-loop/ValidationLoopDemo.tsx
+++ b/src/patterns/streaming-validation-loop/ValidationLoopDemo.tsx
@@ -194,7 +194,12 @@ export function ValidationLoopDemo() {
               <p>Budget analyses will appear here as the stream progresses...</p>
             </div>
           ) : (
-            <div className={styles.analysesList}>
+            <div
+              role="log"
+              aria-live="polite"
+              aria-label="Streaming budget analyses"
+              className={styles.analysesList}
+            >
               {Array.from(analyses.entries()).map(([team, analysis]) => (
                 <div key={team} className={styles.analysisCard}>
                   <h4>{team} Team</h4>
@@ -234,7 +239,12 @@ export function ValidationLoopDemo() {
           {allocations.length > 0 && (
             <div className={styles.allocations}>
               <h3>Approved Allocations</h3>
-              <div className={styles.allocationsList}>
+              <div
+                role="log"
+                aria-live="polite"
+                aria-label="Approved budget allocations"
+                className={styles.allocationsList}
+              >
                 {allocations.map((allocation) => (
                   <div key={allocation.team} className={styles.allocationCard}>
                     <div className={styles.allocationHeader}>

--- a/src/patterns/tabular-stream-view/TabularStreamViewDemo.tsx
+++ b/src/patterns/tabular-stream-view/TabularStreamViewDemo.tsx
@@ -294,14 +294,20 @@ export function TabularStreamViewDemo(): JSX.Element {
           />
 
           {/* Streaming Table */}
-          <StreamingTable
-            schema={schema}
-            rows={visibleRows}
-            isStreaming={isStreaming}
-            isComplete={isComplete}
-            sort={sort}
-            onSort={handleHeaderSort}
-          />
+          <div
+            role="log"
+            aria-live="polite"
+            aria-label="Streaming table rows"
+          >
+            <StreamingTable
+              schema={schema}
+              rows={visibleRows}
+              isStreaming={isStreaming}
+              isComplete={isComplete}
+              sort={sort}
+              onSort={handleHeaderSort}
+            />
+          </div>
 
           {/* Completion Footer */}
           <CompletionFooter

--- a/src/patterns/turn-taking-co-creation/TurnTakingDemo.tsx
+++ b/src/patterns/turn-taking-co-creation/TurnTakingDemo.tsx
@@ -142,12 +142,18 @@ const CollaborativeContent = memo(function CollaborativeContent({
           className={styles.turnIndicator}
         />
 
-        <CollaborativeEditor
-          sections={sectionsWithAuthorship}
-          isStreaming={isStreaming}
-          onUserEdit={actions.applyUserEdit}
-          className={styles.editor}
-        />
+        <div
+          role="log"
+          aria-live="polite"
+          aria-label="Collaborative document editor"
+        >
+          <CollaborativeEditor
+            sections={sectionsWithAuthorship}
+            isStreaming={isStreaming}
+            onUserEdit={actions.applyUserEdit}
+            className={styles.editor}
+          />
+        </div>
       </div>
 
       {/* Right Column: Sidebar */}


### PR DESCRIPTION
## Ticket
Closes #217
https://github.com/vibeacademy/streaming-patterns/issues/217

## Summary
Added proper ARIA live regions to all 7 streaming pattern demos to ensure screen readers announce dynamic content updates. This critical accessibility fix ensures blind users can access streaming content as it appears.

## Changes Made

### Chain of Reasoning (ChainOfReasoningDemo.tsx)
- Added `role="log" aria-live="polite"` wrapper around ReasoningBeadline component
- Added ARIA attributes to final answer section for screen reader announcements

### Agent Await Prompt (AgentAwaitPromptDemo.tsx)
- Added `role="log" aria-live="polite"` to streaming message text container

### Tabular Stream View (TabularStreamViewDemo.tsx)
- Wrapped StreamingTable component in ARIA live region container

### Multi-Turn Memory (MultiTurnMemoryDemo.tsx)
- Added ARIA live region wrapper around ChatThread component

### Turn-Taking Co-Creation (TurnTakingDemo.tsx)
- Wrapped CollaborativeEditor in ARIA live region for dynamic content announcements

### Streaming Validation Loop (ValidationLoopDemo.tsx)
- Added ARIA attributes to budget analyses list container
- Added ARIA attributes to approved allocations list container

### Schema Governed Exchange (SchemaExchangeDemo.tsx)
- Wrapped PayloadViewer in ARIA live region container

## Accessibility Compliance

All changes follow WCAG 2.1 AA requirements:
- Dynamic content uses `role="log"` for proper semantic structure
- `aria-live="polite"` ensures announcements don't interrupt user navigation
- Clear `aria-label` descriptions for each streaming content area
- Existing `.sr-only` utility class used for status announcements (already present in globals.css)

## Testing

### Automated Tests
- [x] All tests pass (881 passed)
- [x] No TypeScript errors
- [x] Build succeeds (`npm run build`)

### Manual Testing Required
Screen reader testing should verify:
1. VoiceOver (macOS): Cmd+F5 to enable, navigate to each pattern demo
2. NVDA (Windows): Test streaming content announcements
3. Verify announcements are polite (don't interrupt navigation)
4. Confirm new content is announced as it streams in

### Testing Steps
```bash
# 1. Enable VoiceOver (macOS)
Cmd+F5

# 2. Navigate to pattern demo
npm run dev
# Visit http://localhost:5173/patterns/chain-of-reasoning

# 3. Start streaming demo
# Verify screen reader announces:
# - "Generating reasoning steps, please wait" (initial state)
# - Each new reasoning step as it appears
# - "Stream complete, N reasoning steps generated" (final state)

# 4. Repeat for all 7 patterns
```

## Acceptance Criteria
- [x] All streaming content containers have `role="log" aria-live="polite"`
- [x] Loading states use existing screen reader announcements
- [x] Clear aria-label descriptions for all live regions
- [x] No TypeScript compilation errors
- [x] All automated tests pass
- [x] Build succeeds
- [ ] VoiceOver testing passes (requires manual verification)
- [ ] NVDA testing passes (requires manual verification)

## Build Verification
- [x] TypeScript compilation successful
- [x] Vite build successful
- [x] No linting errors
- [x] All unit tests pass (881 passed)
- [x] No new warnings introduced

## References
- UX Audit: docs/UX-AUDIT-REPORT.md (Category 6 - Accessibility)
- ARIA Live Regions: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
- WCAG 2.1: https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html