### PR TITLE
[#238] Fix duplicate errors in schema-governed-exchange

### DIFF
--- a/src/patterns/schema-governed-exchange/hooks.ts
+++ b/src/patterns/schema-governed-exchange/hooks.ts
@@ -174,6 +174,8 @@ export function useSchemaValidation(options: MockStreamOptions = {}) {
 
   /**
    * Handle schema error events from stream
+   *
+   * Deduplicates errors by field - only keeps the most recent error for each field.
    */
   const handleSchemaError = useCallback((event: SchemaErrorEvent) => {
     const error: ValidationError = {
@@ -184,7 +186,12 @@ export function useSchemaValidation(options: MockStreamOptions = {}) {
       code: event.data.code,
     };
 
-    setStreamErrors((prev) => [...prev, error]);
+    setStreamErrors((prev) => {
+      // Remove any existing error for this field
+      const filtered = prev.filter(e => e.field !== error.field);
+      // Add the new error
+      return [...filtered, error];
+    });
   }, []);
 
   return {


### PR DESCRIPTION
## Ticket
Closes #238

## Summary
Fixed duplicate error display in the schema-governed-exchange pattern's "errors" scenario. The pattern was showing 15 errors when only 8 unique fields had validation errors, with some errors being duplicated multiple times as the payload accumulated.

## Changes Made
- `/src/patterns/schema-governed-exchange/hooks.ts`: Modified `handleSchemaError` function to deduplicate errors by field name

## Root Cause
The `handleSchemaError` function was using `[...prev, error]` which kept appending all schema_error events to the errors array. In the errorValidationStream fixture, as the payload builds up progressively, the same fields (like `projectName`, `budget`) receive multiple schema_error events, causing duplicates to accumulate.

## Solution
Implemented error deduplication logic:
1. Filter out any existing error for the same field
2. Add the new error (keeping only the most recent error per field)

This ensures that each field only shows one error at a time, accurately reflecting the current validation state.

## Behavior Change
**Before**: 15 total errors displayed (with duplicates)
**After**: 8 unique errors displayed (one per field: projectName, budget, teamIds, deadline, priority, owner.userId, owner.email)

## Testing
### Automated Tests
- [x] Unit tests pass
- [x] Component tests pass
- [x] Integration tests pass
- [x] Coverage meets threshold

### Manual Testing
1. Run `npm run dev`
2. Navigate to `/patterns/schema-governed-exchange`
3. Select "Validation Errors" scenario
4. Click "Start Stream"
5. Verify that error count matches the number of unique fields with errors (8)
6. Verify no duplicate errors appear for the same field

## Checklist
- [x] All tests pass (`npm test -- --run schema`)
- [x] Code follows TypeScript strict mode
- [x] Added JSDoc comment explaining deduplication
- [x] No eslint warnings
- [x] Built successfully (`npm run build`)