### PR TITLE
[#215] Fix hardcoded error background color in PayloadViewer

### DIFF
--- a/src/patterns/schema-governed-exchange/PayloadViewer.module.css
+++ b/src/patterns/schema-governed-exchange/PayloadViewer.module.css
@@ -91,7 +91,7 @@
 }
 
 .errorLine {
-  background: rgba(239, 68, 68, 0.1); /* error-500 with alpha */
+  background: color-mix(in srgb, var(--color-error-500) 10%, transparent);
   display: inline-block;
   width: 100%;
 }


### PR DESCRIPTION
## Ticket
Closes #215
Part of #203 (Dark Mode Compliance)

## Summary
Fixed hardcoded rgba error background color in PayloadViewer to use semantic color variables, ensuring proper dark mode compliance and theme consistency.

## Changes Made
- `/src/patterns/schema-governed-exchange/PayloadViewer.module.css`: Line 94
  - **Before**: `background: rgba(239, 68, 68, 0.1);` (hardcoded red with alpha)
  - **After**: `background: color-mix(in srgb, var(--color-error-500) 10%, transparent);`

## Why This Matters
Hardcoded colors break in dark mode and don't respect the design system's semantic color tokens. Using `color-mix()` with `var(--color-error-500)` ensures:
1. Proper theming support (adapts to dark/light mode automatically)
2. Consistency with design system
3. Same visual appearance (10% opacity red background for error lines)

## Testing
### Automated Tests
- [x] All tests pass
- [x] Built successfully

### Manual Testing
1. Run `npm run dev`
2. Navigate to `/patterns/schema-governed-exchange`
3. Select "Validation Errors" scenario
4. Click "Start Stream"
5. Verify error lines have red background highlight
6. Toggle dark mode (if available) to verify proper theming
7. Compare visual appearance with original - should be identical

## Visual Regression Check
No visual change expected - this is a 1:1 replacement using semantic colors.

## Checklist
- [x] Uses semantic color variable (`--color-error-500`)
- [x] Maintains 10% opacity for subtle background
- [x] No visual regressions
- [x] Built successfully (`npm run build`)
- [x] Code follows CSS standards

## References
- UX Audit Report: `docs/UX-AUDIT-REPORT.md` (Category 1, P1 violations)
- Parent Epic: #203 (Dark Mode Compliance)