### PR TITLE
[#218] Fix skip navigation link styling for keyboard accessibility

### DIFF
--- a/src/components/layout/AppShell.module.css
+++ b/src/components/layout/AppShell.module.css
@@ -9,6 +9,28 @@
   background-color: var(--color-bg-secondary);
 }
 
+/* ===== SKIP LINK ===== */
+
+.skipLink {
+  position: absolute;
+  left: -9999px;
+  z-index: var(--z-index-modal);
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-primary);
+  color: white;
+  text-decoration: none;
+  font-weight: var(--font-weight-medium);
+  border-radius: var(--border-radius-md);
+}
+
+.skipLink:focus {
+  left: var(--space-4);
+  top: var(--space-4);
+  box-shadow: var(--shadow-focus);
+  outline: 2px solid var(--color-primary-700);
+  outline-offset: 2px;
+}
+
 /* ===== HEADER ===== */
 
 .header {

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -55,7 +55,7 @@ export function AppShell({
   return (
     <div className={classNames}>
       {/* Skip to main content link for accessibility */}
-      <a href="#main-content" className="skip-to-main">
+      <a href="#main-content" className={styles.skipLink}>
         Skip to main content
       </a>
 


### PR DESCRIPTION
## Ticket
Addresses #218 (partially)
Part of #204 (WCAG 2.1 Accessibility Compliance)

## Summary
Fixed the skip navigation link in AppShell component to properly support keyboard accessibility. The link was present in the markup but lacked proper styling to be functional.

## Changes Made

### 1. Fixed Skip Link Reference (`AppShell.tsx`)
**Before**:
```tsx
<a href="#main-content" className="skip-to-main">
```
**After**:
```tsx
<a href="#main-content" className={styles.skipLink}>
```

Changed from hardcoded string className to proper CSS module reference.

### 2. Added Skip Link Styles (`AppShell.module.css`)
```css
.skipLink {
  position: absolute;
  left: -9999px;  /* Hidden off-screen by default */
  z-index: var(--z-index-modal);  /* Appears above all content */
  padding: var(--space-2) var(--space-4);
  background: var(--color-primary);
  color: white;
  text-decoration: none;
  font-weight: var(--font-weight-medium);
  border-radius: var(--border-radius-md);
}

.skipLink:focus {
  left: var(--space-4);  /* Appears at top-left when focused */
  top: var(--space-4);
  box-shadow: var(--shadow-focus);
  outline: 2px solid var(--color-primary-700);
  outline-offset: 2px;
}
```

## Files Modified
- `/src/components/layout/AppShell.tsx`
- `/src/components/layout/AppShell.module.css`

## How It Works
1. **Default State**: Skip link is positioned off-screen (`left: -9999px`), invisible to sighted users
2. **Keyboard Focus**: When user presses Tab, skip link receives focus and slides into view at top-left
3. **Activation**: User can press Enter to jump directly to `#main-content`, bypassing header navigation
4. **Visual Clarity**: High contrast (primary blue background, white text) with clear focus outline

## WCAG 2.1 Compliance
- ✅ **2.4.1 Bypass Blocks (Level A)**: Provides mechanism to skip repetitive navigation
- ✅ **2.4.7 Focus Visible (Level AA)**: Clear visual focus indicator
- ✅ **1.4.3 Contrast (Level AA)**: High contrast colors for visibility

## Testing

### Automated Tests
- [x] TypeScript compiles successfully
- [x] Built successfully

### Manual Testing
1. Run `npm run dev`
2. Navigate to any page
3. Press Tab key (should be first focusable element)
4. Verify skip link appears at top-left corner
5. Verify link has blue background and white text
6. Verify clear focus outline
7. Press Enter on skip link
8. Verify focus jumps to main content area
9. Test with screen reader to verify it announces "Skip to main content"

## Note on Scope
This PR addresses the **skip navigation link** portion of issue #218. The aria-labels for icon-only buttons component mentioned in the ticket would require a broader audit of pattern components and may be addressed in a future PR or marked as not applicable if no icon-only buttons exist without labels.

## Checklist
- [x] Skip link uses proper CSS module class
- [x] Skip link hidden by default
- [x] Skip link visible on keyboard focus
- [x] Skip link positioned correctly when visible
- [x] Uses semantic color tokens
- [x] High z-index ensures visibility
- [x] Clear focus indicator
- [x] Links to correct target (#main-content)
- [x] Built successfully

## References
- WCAG 2.1 Bypass Blocks: https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html
- WebAIM Skip Navigation: https://webaim.org/techniques/skipnav/
- UX Audit: `docs/UX-AUDIT-REPORT.md` (Category 6)
- Parent Epic: #204 (WCAG 2.1 Accessibility Compliance)