### PR TITLE
[#214] Fix Chain of Reasoning pattern theme colors

### DIFF
--- a/src/patterns/chain-of-reasoning/ReasoningBeadline.module.css
+++ b/src/patterns/chain-of-reasoning/ReasoningBeadline.module.css
@@ -146,7 +146,7 @@
 .summary {
   font-size: var(--font-size-lg);
   font-weight: 600;
-  color: var(--color-neutral-900);
+  color: var(--color-text-primary);
   line-height: 1.4;
   margin: 0;
 }


### PR DESCRIPTION
## Ticket
Closes #214
https://github.com/vibeacademy/streaming-patterns/issues/214

## Summary
Fixed theme color violations in the Chain of Reasoning pattern by replacing hardcoded neutral color with semantic text color variable for proper dark mode support.

## Changes Made
- **ReasoningBeadline.module.css (line 149)**: Changed `color: var(--color-neutral-900)` to `color: var(--color-text-primary)`

## Notes
The issue description mentioned a second violation in PayloadViewer.module.css (line 94), but upon inspection, this file already uses the correct implementation:
```css
background: color-mix(in srgb, var(--color-error-500) 10%, transparent);
```
This is compliant with the UX standards and supports dark mode properly.

## Testing
### Automated Tests
- [x] Unit tests pass
- [x] Component tests pass  
- [x] Integration tests pass
- [x] Coverage meets threshold

### Build Verification
- [x] Built successfully (`npm run build`)
- [x] No eslint warnings
- [x] No TypeScript errors

### Manual Testing
1. Text color now uses semantic variable that adapts to theme
2. Pattern maintains readability in both light and dark modes
3. No visual regressions in the reasoning bead line display

## Checklist
- [x] All tests pass (`npm test`)
- [x] Code follows TypeScript strict mode
- [x] Uses semantic color variables
- [x] No eslint warnings
- [x] Built successfully (`npm run build`)
- [x] Pattern works in dark mode
- [x] No visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)