### PR TITLE
Fix memory card tooltip visibility in production

### DIFF
--- a/src/patterns/multi-turn-memory/MemoryCard.module.css
+++ b/src/patterns/multi-turn-memory/MemoryCard.module.css
@@ -124,10 +124,10 @@
   color: white;
 }
 
-/* Provenance Tooltip */
+/* Provenance Tooltip - positioned below card to avoid overflow clipping */
 .provenanceTooltip {
   position: absolute;
-  bottom: calc(100% + 8px);
+  top: calc(100% + 8px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 1000;
@@ -138,17 +138,17 @@
   border: 1px solid var(--color-border-light);
   border-radius: var(--border-radius-lg);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  animation: fadeIn 0.2s ease;
+  animation: fadeInDown 0.2s ease;
 }
 
-.provenanceTooltip::after {
+.provenanceTooltip::before {
   content: '';
   position: absolute;
-  top: 100%;
+  bottom: 100%;
   left: 50%;
   transform: translateX(-50%);
   border: 6px solid transparent;
-  border-top-color: var(--color-bg-primary);
+  border-bottom-color: var(--color-bg-primary);
 }
 
 .tooltipHeader {
@@ -231,7 +231,16 @@
 @keyframes fadeIn {
   from {
     opacity: 0;
-    transform: translateX(-50%) translateY(4px);
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeInDown {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-4px);
   }
   to {
     opacity: 1;

--- a/src/patterns/multi-turn-memory/MemoryTimeline.module.css
+++ b/src/patterns/multi-turn-memory/MemoryTimeline.module.css
@@ -17,8 +17,9 @@
   gap: 1rem;
   overflow-x: auto;
   overflow-y: visible;
-  padding-bottom: 0.5rem;
-  padding-top: 1rem;
+  padding-bottom: 6rem; /* Space for tooltip below cards */
+  padding-top: 0.5rem;
+  margin-bottom: -5rem; /* Reclaim vertical space */
   scroll-behavior: smooth;
 }
 


### PR DESCRIPTION
## Summary
- Fixes tooltip not appearing on hover for memory cards at https://streamingpatterns.com/patterns/multi-turn-memory

## Problem
The tooltip was positioned ABOVE the card (`bottom: calc(100% + 8px)`), but `overflow-x: auto` on the scroll container creates a clipping context that hides the tooltip.

## Solution
- Repositioned tooltip BELOW the card (`top: calc(100% + 8px)`)
- Added padding below scroll container for tooltip space
- Updated arrow direction and animation

## Test Plan
- [x] Build passes
- [x] All 881 tests pass
- [ ] Verify tooltip visible on preview deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)