### PR TITLE
[#255] Fix validation error counting and deduplication

### DIFF
--- a/src/patterns/schema-governed-exchange/ValidationBadge.tsx
+++ b/src/patterns/schema-governed-exchange/ValidationBadge.tsx
@@ -11,14 +11,16 @@ import styles from './ValidationBadge.module.css';
 
 export interface ValidationBadgeProps {
   validationResult: ValidationResult;
+  totalErrors?: number;
   showDescription?: boolean;
 }
 
 export function ValidationBadge({
   validationResult,
+  totalErrors,
   showDescription = true,
 }: ValidationBadgeProps) {
-  const { label, color, description } = useValidationStatus(validationResult);
+  const { label, color, description } = useValidationStatus(validationResult, totalErrors);
 
   return (
     <div

--- a/src/patterns/schema-governed-exchange/hooks.ts
+++ b/src/patterns/schema-governed-exchange/hooks.ts
@@ -271,13 +271,18 @@ export function useAutoFixSuggestions(errors: ValidationError[]) {
 /**
  * Hook for validation status badge
  */
-export function useValidationStatus(validationResult: ValidationResult): {
+export function useValidationStatus(
+  validationResult: ValidationResult,
+  totalErrors?: number
+): {
   status: ValidationStatus;
   label: string;
   color: 'green' | 'amber' | 'red' | 'gray';
   description: string;
 } {
   const { status, errors } = validationResult;
+  // Use totalErrors if provided, otherwise fall back to errors.length
+  const errorCount = totalErrors !== undefined ? totalErrors : errors.length;
 
   switch (status) {
     case 'valid':
@@ -301,7 +306,7 @@ export function useValidationStatus(validationResult: ValidationResult): {
         status: 'invalid',
         label: 'Invalid',
         color: 'red',
-        description: `${errors.length} validation error${errors.length === 1 ? '' : 's'}`,
+        description: `${errorCount} validation error${errorCount === 1 ? '' : 's'}`,
       };
 
     case 'pending':


### PR DESCRIPTION
## Ticket
Closes #255

## Summary
Fixed incorrect and mismatched validation error counts in the schema-governed-exchange pattern. The ValidationBadge and ErrorHighlighter were showing different counts (8 and 15) because they were counting errors from different sources without deduplication.

## Root Cause Analysis
The bug occurred due to two issues:

1. **Different error sources**: 
   - `ValidationBadge` counted only `validationResult.errors` (Zod validation errors)
   - `ErrorHighlighter` counted `allErrors` (Zod errors + stream errors combined)

2. **No deduplication**: When the same field had errors from both Zod validation and stream events, it was counted twice in `allErrors`

## Changes Made

### Error Deduplication (SchemaExchangeDemo.tsx)
- Implemented `Map`-based deduplication by field name using `React.useMemo`
- Stream errors override Zod errors (they contain better auto-fix suggestions)
- Both displays now use the same deduplicated `allErrors` array

### ValidationBadge Component
- Added optional `totalErrors` prop to accept the deduplicated count
- Component now receives accurate error count from parent

### useValidationStatus Hook
- Updated to accept optional `totalErrors` parameter
- Falls back to `validationResult.errors.length` for backward compatibility
- Uses `totalErrors` when provided for accurate count display

### Test Coverage
- Added new test: "should deduplicate errors and show consistent error count"
- Test verifies that ValidationBadge and ErrorHighlighter show identical counts
- Uses fast speed for quicker test execution

## Testing

### Automated Tests
- [x] All 882 tests pass
- [x] New test verifies error count consistency
- [x] TypeScript strict mode compliance maintained
- [x] Build succeeds with no errors

### Manual Testing
To verify the fix manually:
1. Run `npm run dev`
2. Navigate to `/patterns/schema-governed-exchange`
3. Select "❌ Errors" scenario
4. Click "Start Stream"
5. Verify ValidationBadge shows "7 validation errors"
6. Verify ErrorHighlighter header shows "Validation Errors (7)"
7. Both counts should match

## Expected Error Count
For the "with-errors" scenario, the correct count is **7 unique errors**:
1. projectName (too short)
2. budget (wrong type)
3. teamIds (wrong type)
4. deadline (past date)
5. priority (invalid enum)
6. owner.userId (invalid UUID)
7. owner.email (invalid email)

Previously, these were being counted multiple times due to duplication between Zod and stream errors.

## Files Changed
- `src/patterns/schema-governed-exchange/SchemaExchangeDemo.tsx` - Added deduplication logic
- `src/patterns/schema-governed-exchange/ValidationBadge.tsx` - Added totalErrors prop
- `src/patterns/schema-governed-exchange/hooks.ts` - Updated useValidationStatus hook
- `src/patterns/schema-governed-exchange/SchemaExchangeDemo.test.tsx` - Added deduplication test

## Checklist
- [x] All tests pass (`npm test`)
- [x] Code follows TypeScript strict mode
- [x] Components have prop interfaces
- [x] Error deduplication is deterministic
- [x] No eslint warnings
- [x] Built successfully (`npm run build`)
- [x] Educational value maintained (comments explain deduplication logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)