### PR TITLE
[#270] Enable GitHub Discussions and update documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -618,9 +618,10 @@ We're here to help you contribute successfully!
 
 ### Getting Support
 
-- **Questions about code**: Open a [GitHub Discussion](https://github.com/vibeacademy/streaming-patterns/discussions)
+- **Questions about the library**: Visit [GitHub Discussions](https://github.com/vibeacademy/streaming-patterns/discussions) for Q&A, pattern ideas, and community support
 - **Bug reports**: Open a [GitHub Issue](https://github.com/vibeacademy/streaming-patterns/issues)
 - **Feature requests**: Open a [GitHub Issue](https://github.com/vibeacademy/streaming-patterns/issues) with the "enhancement" label
+- **Show & Tell**: Share projects you've built using these patterns in [GitHub Discussions](https://github.com/vibeacademy/streaming-patterns/discussions)
 - **Security issues**: See SECURITY.md (if applicable)
 
 ### Common Issues

--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ We welcome contributions! Whether it's:
 3. Follow the trunk-based development workflow
 4. Ensure tests pass and coverage >80%
 
+**Have questions?** Join the discussion in [GitHub Discussions](https://github.com/vibeacademy/streaming-patterns/discussions) to ask questions, share ideas, or show off what you've built!
+
 **Development Workflow:**
 1. Create feature branch: `feature/issue-{number}-description`
 2. Implement with tests
@@ -385,6 +387,7 @@ MIT License - see [LICENSE](./LICENSE) for details.
 ## Learn More
 
 - **Live Demo**: [streamingpatterns.com](https://streamingpatterns.com)
+- **GitHub Discussions**: [Ask questions, share ideas, and show your projects](https://github.com/vibeacademy/streaming-patterns/discussions)
 - **GitHub Issues**: [Report bugs or request features](https://github.com/vibeacademy/streaming-patterns/issues)
 - **Project Board**: [Track development progress](https://github.com/orgs/vibeacademy/projects/3)
 


### PR DESCRIPTION
## Ticket
Closes #270
https://github.com/vibeacademy/streaming-patterns/issues/270

## Summary
Updates documentation to reference GitHub Discussions as a community resource for Q&A, pattern ideas, and showcasing projects built with the Streaming Patterns Library.

## Changes Made
- **README.md**:
  - Added GitHub Discussions link in the "Contributing" section with context about asking questions and sharing projects
  - Added GitHub Discussions to the "Learn More" section with descriptive text
- **CONTRIBUTING.md**:
  - Updated "Getting Support" section to highlight GitHub Discussions for Q&A and community support
  - Added "Show & Tell" mention for sharing projects built with the library
  - Clarified the different use cases: Discussions for questions, Issues for bugs/features

## Action Required by Human Admin
**IMPORTANT**: A human with admin permissions must enable Discussions in the repository settings:

1. Navigate to **Settings** > **Features**
2. Check the box to **Enable Discussions**
3. Create the following categories:
   - **Q&A** (for questions about using the patterns)
   - **Pattern Ideas** (for suggesting new patterns)
   - **Show & Tell** (for showcasing projects)
   - **General** (for general discussion)
4. Pin a welcome post to introduce the community

## Testing
### Manual Verification
1. ✅ Reviewed changes in README.md
2. ✅ Reviewed changes in CONTRIBUTING.md
3. ✅ Verified links point to correct GitHub Discussions URL
4. ✅ Ensured consistent messaging across both files
5. ✅ Confirmed no markdown syntax errors

### Build Verification
The changes are documentation-only and don't affect the codebase functionality. However, the build can be verified with:
```bash
npm run build
```

## Checklist
- [x] Documentation follows existing style and tone
- [x] Links are properly formatted
- [x] Changes are consistent across README.md and CONTRIBUTING.md
- [x] Commit message follows guidelines
- [x] Branch naming follows convention
- [x] PR references the issue number

🤖 Generated with [Claude Code](https://claude.com/claude-code)